### PR TITLE
Load rapidapi key via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,15 @@
 - **Frontend**  
   React / Vite / Tailwind / shadcn
 
-- **Blockchain SDK**  
+- **Blockchain SDK**
   Rapid API-NBA
+
+## Running the application
+
+Set the RapidAPI key as an environment variable before starting the backend:
+
+```bash
+export RAPIDAPI_KEY=your-api-key
+```
+
+The backend reads this value via the `rapidapi.key` property.

--- a/backend/src/main/java/com/nba/realtime/misc/RapidProperties.java
+++ b/backend/src/main/java/com/nba/realtime/misc/RapidProperties.java
@@ -2,6 +2,7 @@ package com.nba.realtime.misc;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,5 +18,7 @@ public class RapidProperties {
 
     private String url;
     private String host;
+
+    @Value("${rapidapi.key}")
     private String key;
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -20,5 +20,4 @@ security:
 rapidapi:
   url: https://api-nba-v1.p.rapidapi.com/
   host: api-nba-v1.p.rapidapi.com
-  key: 46bbc8c6c3msh4275edccf81780bp1935bbjsnc882a902fb97
 


### PR DESCRIPTION
## Summary
- remove Rapid API key from application.yml
- bind `RapidProperties.key` to `${rapidapi.key}` environment property
- document how to run the backend with `RAPIDAPI_KEY`

## Testing
- `./mvnw -q test` *(fails: wget Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_684653acced0832e8947a990c345c0c0